### PR TITLE
fix cancel follow text too long

### DIFF
--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -132,7 +132,7 @@ module UsersHelper
     icon = '<i class="fa fa-user"></i>'
     login = user.login.downcase
     if followed
-      link_to raw("#{icon} <span>取消关注</span>"), '#', 'data-id' => login, class: "#{class_names} active"
+      link_to raw("#{icon} <span>取消</span>"), '#', 'data-id' => login, class: "#{class_names} active"
     else
       link_to raw("#{icon} <span>关注</span>"), '#', title: '', 'data-id' => login, class: class_names
     end


### PR DESCRIPTION
修复 “取消关注” 在帖子右侧边栏处由于长度过长超出按钮范围的问题。