### PR TITLE
Fix text of cancel follow in sidebox out of bound

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -279,6 +279,7 @@ a {
 .btn-success:hover { background:$greenLight; border-color: $green; }
 .btn-success.active { background:$greenDark; border-color: $greenDark; }
 .open>.dropdown-toggle.btn-primary { background: #0059C7; }
+.button-follow-user {padding: 5px 10px;}
 
 .navbar-btn {
   background: rgba(255, 255, 255, 0.1);


### PR DESCRIPTION
修复取消关注在 Chrome 44 上会超出边界的问题。现在增加了一个专用样式，把 padding 改小了，那么“取消关注”会自动居中，不会再超出边界。