### PR TITLE
Fix hide voter

### DIFF
--- a/app/assets/javascripts/polls.coffee
+++ b/app/assets/javascripts/polls.coffee
@@ -122,6 +122,17 @@ window.Poll =
           $voters_list.empty()
       else
         $voters_list.empty()
+    # hide voters when clicking outside
+    $('body').on 'click', (e) ->
+      $('a.voters-popover').each ->
+        # the 'is' for buttons that trigger popups
+        # the 'has' for icons within a button that triggers a popup
+        if !$(this).is(e.target) && $(this).has(e.target).length == 0 && $('.popover').has(e.target).length == 0
+          $(this).popover('hide');
+
+
+
+
 
   formRemoveOption: ->
     $(@form).on 'click', ".poll-options button[name=remove-option]", (e) ->

--- a/app/views/polls/_options.html.erb
+++ b/app/views/polls/_options.html.erb
@@ -34,7 +34,7 @@
             <span class="info"><%= opt.voters_count %></span>
             <% if poll.public_mode %>
                 <% if opt.voters_count > 0 %>
-                    <a tabindex="0" href="javascript:void(0);" title="投票用户" data-placement="right" data-bs="popover" class="voters-popover" data-poll-id="<%= poll.id %>" data-oid="<%= opt.oid %>"><i class="fa fa-user"></i></a>
+                    <a tabindex="0" href="javascript:void(0);" title="投票用户" data-placement="bottom" data-bs="popover" class="voters-popover" data-poll-id="<%= poll.id %>" data-oid="<%= opt.oid %>"><i class="fa fa-user"></i></a>
                 <% end %>
             <% end %>
           </td>


### PR DESCRIPTION
1. 点击投票人弹出窗口以外的位置，弹出窗口会自动消失。避免出现重叠。
2. 调整投票人弹出框位置，改为在按钮下方。这种方式在手机上看效果好一些。