### PR TITLE
Fix voter next page

### DIFF
--- a/app/controllers/polls_controller.rb
+++ b/app/controllers/polls_controller.rb
@@ -9,7 +9,7 @@ class PollsController < ApplicationController
     if @users.nil?
       @users = User.only(:_id, :name, :avatar, :email_md5, :login)
                    .where(_id: { '$in' => voters_ids })
-                   .paginate(page: params[:page], per_page: 50)
+                   .paginate(page: params[:page], per_page: 10)
       if Rails.env.production?
         Rails.cache.write(cache_key_for_voters, @users, expires_in: 6.hours)
       end

--- a/app/views/polls/voters.html.erb
+++ b/app/views/polls/voters.html.erb
@@ -5,5 +5,7 @@
     <% end %>
   </ul>
   <%= will_paginate @users %> <!-- hide pagination -->
-  <a href="javascript:void(0);" class="voters-next-page pull-right">更多 &#187;</a>
+  <% if @users.total_pages != @users.current_page%>
+    <a href="javascript:void(0);" class="voters-next-page pull-right">更多 &#187;</a>
+  <% end %>
 </div>


### PR DESCRIPTION
1. 调整每页投票人数量。从50降低到10。50人在手机上显示效果不好。
2. 当没有下一页时，不显示“更多”，进而修复在最后一页点击“更多”出现空白页的问题。