### PR TITLE
修复后台无法更新用户信息的问题

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -37,7 +37,7 @@ module Admin
     end
 
     def update
-      @user = User.find_login!(params[:id])
+      @user = User.find_login(params[:id])
       @user.email = params[:user][:email]
       @user.login = params[:user][:login]
       @user.state = params[:user][:state]


### PR DESCRIPTION
修复后台无法更新用户信息的问题。 原因是方法 find_login 名字变成了 find_login!