### PR TITLE
用户主页卡片变更

### DIFF
--- a/app/assets/stylesheets/users.scss
+++ b/app/assets/stylesheets/users.scss
@@ -195,6 +195,18 @@ table.node-topics {
       border-top: 1px solid #f0f0f0;
       margin-top: 15px; padding-top: 15px;
     }
+    .social {
+      font-size: 18px;
+      a { color: #999; margin-right: 8px; }
+      a:hover { color: #666; }
+    }
+    .tagline {
+      border-top: 1px solid #f0f0f0;
+      margin-top: 10px;
+      color: #999;
+      line-height: 100%;
+      padding: 10px; padding-bottom: 0;
+    }
   }
 }
 

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -64,23 +64,6 @@ module UsersHelper
     end
   end
 
-  def render_user_join_time(user)
-    I18n.l(user.created_at.to_date, format: :long)
-  end
-
-  def render_user_tagline(user)
-    user.tagline
-  end
-
-  def render_user_github_url(user)
-    link_to(user.github_url, user.github_url, target: '_blank', rel: 'nofollow')
-  end
-
-  def render_user_personal_website(user)
-    website = user.website[%r{^https?://}] ? user.website : 'http://' + user.website
-    link_to(website, website, target: '_blank', class: 'url', rel: 'nofollow')
-  end
-
   def render_user_level_tag(user)
     return '' if user.blank?
     level_class = case user.level

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -183,6 +183,10 @@ class User
     "https://github.com/#{self.github.split('/').last}"
   end
 
+  def website_url
+    website[%r{^https?://}] ? website : "http://#{website}"
+  end
+
   def twitter_url
     return "" if self.twitter.blank?
     "https://twitter.com/#{self.twitter}"

--- a/app/views/users/_info.html.erb
+++ b/app/views/users/_info.html.erb
@@ -1,47 +1,14 @@
+<script src="//ruby-china-files.b0.upaiyun.com/assets/d3.min.js" data-turbolinks-track="true" type="text/javascript"></script>
+<script src="//ruby-china-files.b0.upaiyun.com/assets/cal-heatmap.min.js" data-turbolinks-track="true" type="text/javascript"></script>
+
 <div class="panel panel-default userinfo">
-  <ul class="list-group vcard">
 
-    <% if !@user.company.blank? %>
-        <li class="adr list-group-item">
-          <label><%= t("users.company") %>:</label>
-          <span class="org"><%= @user.company %></span>
-        </li>
-    <% end %>
-
-    <% if !@user.email.blank? && @user.email_public %>
-        <li class="list-group-item">
-          <label>Email:</label>
-          <span><%= auto_link @user.email %></span>
-        </li>
-    <% end %>
-
-    <% if !@user.twitter.blank? %>
-        <li class="list-group-item">
-          <label><%= t("users.twitter") %>:</label>
-          <span><%= link_to "@#{@user.twitter}", @user.twitter_url, class: "twitter", rel: "nofollow" %></span>
-        </li>
-    <% end %>
-
-    <% if !@user.website.blank? %>
-        <li class="list-group-item">
-          <label><%= t("users.personal_website") %>:</label>
-          <span><%= render_user_personal_website(@user) %></span>
-        </li>
-    <% end %>
-
-    <% if !@user.tagline.blank? %>
-        <li class="list-group-item">
-          <label><%= t("users.signature") %>:</label>
-          <span><%= render_user_tagline(@user) %></span>
-        </li>
-    <% end %>
 
     <li class="list-group-item">
       <label><%= t("users.score") %>:</label>
       <span><%= @user.score %></span>
     </li>
 
-  </ul>
   <div class="panel-body">
     <div id="cal-heatmap" class="user-activity-graph"></div>
     <%

--- a/app/views/users/_sidebar.html.erb
+++ b/app/views/users/_sidebar.html.erb
@@ -16,15 +16,35 @@
             </span>
                     </div>
                     <div class="item number">
-                        第 <%= @user.id %> 位<%= t("menu.users")%>
+                      第 <%= @user.id %> 位<%= t("menu.users")%> / <span title="注册日期"><%= @user.created_at.to_date %></span>
                     </div>
-                    <div class="item number">
-                        <span title="注册日期"><%= @user.created_at.to_date %></span>
-                        <% if @user.location.present? %> • <span title="所在地"><%= location_name_tag(@user.location) %></span><% end %>
+          <% if !@user.company.blank? %>
+          <div class="item company">
+            <%= @user.company %>
+            <% if @user.location.present? %> @ <span title="所在地"><%= location_name_tag(@user.location) %></span><% end %>
                     </div>
+          <% end %>
                     <div class="item counts">
                         <span><%= @user.topics_count %></span> 篇帖子 • <span><%= @user.replies_count %></span> 条回帖
                     </div>
+          <div class="item social">
+
+            <% if !@user.twitter.blank? %>
+              <%= link_to raw('<i class="fa fa-twitter"></i>'), @user.twitter_url, class: "twitter", rel: "nofollow" %>
+            <% end %>
+
+            <% if !@user.website.blank? %>
+              <%= link_to(raw('<i class="fa fa-globe"></i>'), @user.website_url, target: '_blank', rel: 'nofollow') %>
+            <% end %>
+
+            <% if !@user.github.blank? %>
+              <%= link_to(raw('<i class="fa fa-github"></i>'), @user.github_url, target: '_blank', rel: 'nofollow') %>
+            <% end %>
+
+            <% if !@user.email.blank? && @user.email_public %>
+              <a href="mailto: <%= @user.email %>"><i class="fa fa-envelope-o"></i></a>
+            <% end %>
+          </div>
                 </div>
             </div>
             <div class="follow-info row">
@@ -50,6 +70,12 @@
                     <div class="col-sm-6">
                         <%= block_user_tag(@user) %>
                     </div>
+      </div>
+      <% end %>
+
+      <% if !@user.tagline.blank? %>
+      <div class="tagline row">
+        <%= @user.tagline %>
                 </div>
             <% end %>
         </div>

--- a/spec/helpers/users_helper_spec.rb
+++ b/spec/helpers/users_helper_spec.rb
@@ -1,48 +1,34 @@
-# coding: utf-8
-require "spec_helper"
+require 'rails_helper'
 
-describe UsersHelper do
-  describe "user_avatar_width_for_size" do
-    it "should calculate avatar width correctly" do
-      helper.user_avatar_width_for_size(:normal).should == 48
-      helper.user_avatar_width_for_size(:small).should == 16
-      helper.user_avatar_width_for_size(:large).should == 64
-      helper.user_avatar_width_for_size(:big).should == 120
-      helper.user_avatar_width_for_size(233).should == 233
+describe UsersHelper, type: :helper do
+  describe 'user_avatar_width_for_size' do
+    it 'should calculate avatar width correctly' do
+      expect(helper.user_avatar_width_for_size(:normal)).to eq(48)
+      expect(helper.user_avatar_width_for_size(:small)).to eq(16)
+      expect(helper.user_avatar_width_for_size(:large)).to eq(96)
+      expect(helper.user_avatar_width_for_size(:big)).to eq(120)
+      expect(helper.user_avatar_width_for_size(233)).to eq(233)
     end
   end
 
-  describe "user_name_tag" do
-    it "should result right html in normal" do
-      user = Factory(:user)
-      helper.user_name_tag(user).should == link_to(user.login, user_path(user.login), 'data-name' => user.name)
+  describe 'user_name_tag' do
+    it 'should result right html in normal' do
+      user = create(:user)
+      expect(helper.user_name_tag(user)).to eq(link_to(user.login, user_path(user.login), 'data-name' => user.name))
     end
 
-    it "should result right html with string param and downcase url" do
-      login = "Monster"
-      helper.user_name_tag(login).should == link_to(login, user_path(login.downcase), 'data-name' => login)
+    it 'should result right html with string param and downcase url' do
+      login = 'Monster'
+      expect(helper.user_name_tag(login)).to eq(link_to(login, user_path(login), 'data-name' => login))
     end
 
-    it "should result empty with nil param" do
-      helper.user_name_tag(nil).should == "匿名"
-    end
-  end
-
-  describe "user personal website" do
-    let(:user) { Factory(:user, :website => 'http://example.com') }
-    subject { helper.render_user_personal_website(user) }
-
-    it { should == link_to(user.website, user.website, :target => "_blank", :class => "url", :rel => "nofollow") }
-
-    context "url without protocal" do
-      before { user.update_attribute(:website, 'example.com') }
-
-      it { should == link_to("http://" + user.website, "http://" + user.website, :class => "url", :target => "_blank", :rel => "nofollow") }
+    it 'should result empty with nil param' do
+      expect(helper.user_name_tag(nil)).to eq('匿名')
     end
   end
 
   describe '.render_user_level_tag' do
-    let(:user) { Factory(:user) }
+    let(:user) { create(:user) }
     subject { helper.render_user_level_tag(user) }
 
     it 'admin should work' do
@@ -58,6 +44,11 @@ describe UsersHelper do
     it 'hr should work' do
       allow(user).to receive(:hr?).and_return(true)
       is_expected.to eq '<span class="label label-success role">企业 HR</span>'
+    end
+
+    it 'blocked should work' do
+      allow(user).to receive(:blocked?).and_return(true)
+      is_expected.to eq '<span class="label label-warning role">禁言用户</span>'
     end
 
     it 'newbie should work' do


### PR DESCRIPTION
效果：
![](https://testerhome.com/photo/2016/6e76765f502aa1c0e2c42f81d9467b09.png)

主要把用户主页、github、twitter 和 邮箱地址变成了头像右侧的图标。