### PR TITLE
Better fix for admin css

### DIFF
--- a/app/assets/stylesheets/admin.scss
+++ b/app/assets/stylesheets/admin.scss
@@ -2,7 +2,10 @@
  *= require application
  *= require_self
  */
-body { color: #333; }
+body {
+  color: #333;
+  padding-top: 0px;
+}
 
 body, p, ol, ul, td {
   font-family: verdana, arial, helvetica, sans-serif;


### PR DESCRIPTION
通过在 admin 专用的 css 里添加规则覆盖原有 css ，保证不会影响管理员以外的页面。