### PR TITLE
修复更新账户信息的提示信息缺少对应 i18n 的问题

### DIFF
--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -1,5 +1,8 @@
-"zh-CN":
+"en":
   account:
     signed_up: 'Sign up successed.'
     updated: 'Profile update successed.'
     destroyed: 'Goodbye! You account was deleted.'
+  registrations:
+    user:
+      updated: 'Your account has been updated successfully.'

--- a/config/locales/devise.zh-CN.yml
+++ b/config/locales/devise.zh-CN.yml
@@ -43,3 +43,6 @@
         subject: '重置密码信息'
       unlock_instructions:
         subject: '解锁信息'
+    registrations:
+      user:
+        updated: '个人资料更新成功'

--- a/config/locales/devise.zh-TW.yml
+++ b/config/locales/devise.zh-TW.yml
@@ -43,3 +43,6 @@
         subject: '重置密碼信息'
       unlock_instructions:
         subject: '解鎖信息'
+    registrations:
+      user:
+        updated: '個人資料更新成功'


### PR DESCRIPTION
修复 TesterHome 更改头像提示 translation missing: zh-CN.devise.registrations.user.updated 的问题

<https://testerhome.com/topics/5555#reply5>